### PR TITLE
Make dict static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,5 +159,6 @@ name = "wordle"
 version = "0.1.0"
 dependencies = [
  "hashbrown",
+ "lazy_static",
  "rand",
 ]

--- a/wordle/Cargo.toml
+++ b/wordle/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 rand = "0.8.4"
 hashbrown = "0.11"
+lazy_static = "1.4.0"

--- a/wordle/src/lib.rs
+++ b/wordle/src/lib.rs
@@ -15,7 +15,7 @@ pub struct WordleMaster {
 }
 
 impl WordleMaster {
-    pub fn new(dict: Vec<&str>) -> Self {
+    pub fn new(dict: &'static Vec<&str>) -> Self {
         let mut rng = rand::thread_rng();
         let target = dict[rng.gen_range(0..dict.len())].to_string();
         let mut letter_vals = HashMap::new();
@@ -56,7 +56,7 @@ impl WordleMaster {
         }
     }
 
-    pub fn run(&mut self, dict: &'static Vec<String>, target: &str, tx_logger: Option<Sender<String>>) {
+    pub fn run(&mut self, dict: &'static Vec<&str>, target: &str, tx_logger: Option<Sender<String>>) {
         let target_clone = target.to_string();
         // self.target = target.to_string();
         let (tx_guess, rx_guess): (Sender<(String, u32)>, Receiver<(String, u32)>) = mpsc::channel();
@@ -117,8 +117,8 @@ impl WordleMaster {
         }
     }
 
-    pub fn guess(&mut self, dict: &'static Vec<String>, guess: &str) -> Option<String> {
-        if !dict.contains(&guess.to_string()){
+    pub fn guess(&mut self, dict: &'static Vec<&str>, guess: &str) -> Option<String> {
+        if !dict.contains(&&&guess) {
             return None;
         }
         self.num_guesses += 1;

--- a/wordle/src/lib.rs
+++ b/wordle/src/lib.rs
@@ -118,7 +118,7 @@ impl WordleMaster {
     }
 
     pub fn guess(&mut self, dict: &'static Vec<&str>, guess: &str) -> Option<String> {
-        if !dict.contains(&&&guess) {
+        if !dict.contains(&guess) {
             return None;
         }
         self.num_guesses += 1;

--- a/wordle/src/lib.rs
+++ b/wordle/src/lib.rs
@@ -7,7 +7,6 @@ use std::thread::{self, JoinHandle};
 #[derive(Debug)]
 pub struct WordleMaster {
     target: String,
-    // dict: Vec<String>,
     guesses: Vec<String>,
     pub num_guesses: u32,
     workers: Vec<WordleSlave>,
@@ -15,23 +14,10 @@ pub struct WordleMaster {
     been_guessed: HashMap<char, bool>,
 }
 
-static GUESS_WORDS: &str = include_str!("../words.txt");
-static SOLN_WORDS: &str = include_str!("../wordlist_solutions.txt");
-
 impl WordleMaster {
-    #[inline]
-    pub fn GUESS_WORDS() -> Vec<&'static str> {
-        GUESS_WORDS.split("\n").map(|x| x.trim()).collect::<Vec<&str>>()
-    }
-
-    #[inline]
-    pub fn SOLN_WRODS() -> Vec<&'static str> {
-        SOLN_WORDS.split("\n").map(|x| x.trim()).collect::<Vec<&str>>()
-    }
-
-    pub fn new(dict: Option<Vec<&str>>) -> Self {
-        // let mut rng = rand::thread_rng();
-        // let target = dict[rng.gen_range(0..dict.len())].to_string();
+    pub fn new(dict: Vec<&str>) -> Self {
+        let mut rng = rand::thread_rng();
+        let target = dict[rng.gen_range(0..dict.len())].to_string();
         let mut letter_vals = HashMap::new();
         letter_vals.insert('a',vec![10; 5]);
         letter_vals.insert('b',vec![3; 5]);
@@ -60,45 +46,39 @@ impl WordleMaster {
         letter_vals.insert('y',vec![3; 5]);
         letter_vals.insert('z',vec![1; 5]);
 
-        let mut been_guessed: HashMap<char, bool> = HashMap::new();
+        let been_guessed: HashMap<char, bool> = HashMap::new();
 
         Self {
-            target: "".to_string(),
-            letter_vals, been_guessed,
+            target, letter_vals, been_guessed,
             guesses: Vec::new(),
-            // dict: dict.iter().map(|x| x.to_string()).collect(),
             num_guesses: 0,
             workers: Vec::new(),
         }
     }
 
-    pub fn run(&mut self, target: &str, tx_logger: Option<Sender<String>>) {
+    pub fn run(&mut self, dict: &'static Vec<String>, target: &str, tx_logger: Option<Sender<String>>) {
         let target_clone = target.to_string();
         // self.target = target.to_string();
         let (tx_guess, rx_guess): (Sender<(String, u32)>, Receiver<(String, u32)>) = mpsc::channel();
 
-        // let dict = self.dict.clone();
         let letter_vals = self.letter_vals.clone();
         let been_guessed = self.been_guessed.clone();
         let num_threads = 4;
-        let dict_chunks = WordleMaster::GUESS_WORDS()
-            .chunks(num_threads);
-
         loop {
             // for each CPU, split the dictionary into equal sizes, and then score them. - This would require sharing the scoring stuff though.
-
             // the problem is that when I split the dictionary, or even when I clone it, it's not really duping the dictionary
             // it must be creating slices to the old memory. I need the dict to disappear entirely.
             // to do this, I need to learn how strings and vectors will copy / clone
             // then figure out how to truly make that happen. Either that, or I need to assure the compiler that these threads
             // will not outlive my function or scope.
-            dict_chunks
-                .map(|&dict_portion| {
+            dict.chunks(num_threads)
+                .map(|dict_portion| {
                     let worker_guesser = tx_guess.clone();
+                    let mut guess: String = String::new();
                     thread::spawn(move || {
                         let mut best_score = 0;
-                        let mut guess: String = String::new();
                         for word in dict_portion {
+
                             let new_score = 20;
                             if new_score > best_score {
                                 guess = word.to_string();
@@ -116,7 +96,7 @@ impl WordleMaster {
                 .unwrap();
 
 
-            match self.guess(&guess) {
+            match self.guess(dict, &guess) {
                 Some(guess) => {
                     if self.num_guesses > 6 {
                         println!("{}  {}", guess, self.num_guesses);
@@ -137,8 +117,8 @@ impl WordleMaster {
         }
     }
 
-    pub fn guess(&mut self, guess: &str) -> Option<String> {
-        if !self.dict.contains(&guess.to_string()){
+    pub fn guess(&mut self, dict: &'static Vec<String>, guess: &str) -> Option<String> {
+        if !dict.contains(&guess.to_string()){
             return None;
         }
         self.num_guesses += 1;

--- a/wordle/src/main.rs
+++ b/wordle/src/main.rs
@@ -16,7 +16,7 @@ fn setup_logging() -> (Sender<String>, JoinHandle<()>) {
 }
 
 lazy_static! {
-    static ref DICT: Vec<&'static str> = include_str!("../words.txt").split("\n").map(|x| x.trim()).collect::<Vec<&'static str>>();
+    static ref DICT: Vec<&'static str> = include_str!("../words.txt").split("\n").map(|x| x.trim()).collect::<Vec<&str>>();
 }
 
 fn main() {

--- a/wordle/src/main.rs
+++ b/wordle/src/main.rs
@@ -16,7 +16,10 @@ fn setup_logging() -> (Sender<String>, JoinHandle<()>) {
 }
 
 lazy_static! {
-    static ref DICT: Vec<&'static str> = include_str!("../words.txt").split("\n").map(|x| x.trim()).collect::<Vec<&str>>();
+    static ref DICT: Vec<&'static str> = {
+        let lines = include_str!("../words.txt").split("\n");
+        lines.map(|x| x.trim()).collect::<Vec<&str>>()
+    };
 }
 
 fn main() {

--- a/wordle/src/main.rs
+++ b/wordle/src/main.rs
@@ -17,7 +17,6 @@ fn setup_logging() -> (Sender<String>, JoinHandle<()>) {
 
 lazy_static! {
     static ref DICT: Vec<&'static str> = include_str!("../words.txt").split("\n").map(|x| x.trim()).collect::<Vec<&'static str>>();
-    static ref DICT_STRING: Vec<String> = DICT.iter().map(|x| x.to_string()).collect::<Vec<String>>();
 }
 
 fn main() {
@@ -29,9 +28,9 @@ fn main() {
 
     let mut guesses_required: Vec<u32> = Vec::new();
     for current_round in 0..solution_dict.len() {
-        let mut wordle = WordleMaster::new(DICT.clone());
+        let mut wordle = WordleMaster::new(&DICT);
         let tx_logger = tx.clone();
-        wordle.run(&DICT_STRING, solution_dict[current_round], Some(tx_logger));
+        wordle.run(&DICT, solution_dict[current_round], Some(tx_logger));
     }
     let total_guesses = guesses_required.iter().sum::<u32>();
     println!("Avg Guesses: {}", total_guesses as f32 / solution_dict.len() as f32);

--- a/wordle/src/main.rs
+++ b/wordle/src/main.rs
@@ -2,6 +2,7 @@ use wordle::{WordleMaster};
 use std::sync::mpsc::{Sender, Receiver};
 use std::sync::mpsc;
 use std::thread::{self, JoinHandle};
+use lazy_static::lazy_static;
 
 fn setup_logging() -> (Sender<String>, JoinHandle<()>) {
     let (tx, rx): (Sender<String>, Receiver<String>) = mpsc::channel();
@@ -14,10 +15,12 @@ fn setup_logging() -> (Sender<String>, JoinHandle<()>) {
     (tx, logger_handle)
 }
 
+lazy_static! {
+    static ref DICT: Vec<&'static str> = include_str!("../words.txt").split("\n").map(|x| x.trim()).collect::<Vec<&'static str>>();
+    static ref DICT_STRING: Vec<String> = DICT.iter().map(|x| x.to_string()).collect::<Vec<String>>();
+}
+
 fn main() {
-    let lines = include_str!("../words.txt").to_string();
-    let dict = lines.split("\n").map(|x| x.trim()).collect::<Vec<&str>>();
-    let dict_copy = dict.clone();
     let solution_lines = include_str!("../wordlist_solutions.txt").to_string();
     let solution_dict = solution_lines.split("\n").map(|x| x.trim()).collect::<Vec<&str>>();
 
@@ -26,9 +29,9 @@ fn main() {
 
     let mut guesses_required: Vec<u32> = Vec::new();
     for current_round in 0..solution_dict.len() {
-        let mut wordle = WordleMaster::new(dict.clone());
+        let mut wordle = WordleMaster::new(DICT.clone());
         let tx_logger = tx.clone();
-        wordle.run(solution_dict[current_round], Some(tx_logger));
+        wordle.run(&DICT_STRING, solution_dict[current_round], Some(tx_logger));
     }
     let total_guesses = guesses_required.iter().sum::<u32>();
     println!("Avg Guesses: {}", total_guesses as f32 / solution_dict.len() as f32);


### PR DESCRIPTION
So the problem I noticed was that dict does not live long enough for the thread to do any computation, so to get around this we can use `lazy_static`s, which let us define static variables at runtime, not compile time, increasing the flexibility we have. The big changes I made are:
1. The `WordleMaster` doesn't track the main dictionary
2. Everything that uses a dict now expects it to be passed into it instead. (Having it in a struct implicitly applies a lifetime to it, the dict can only live as long as the wordle master, so we need to get around that)
3. The `guess` is created in the context of the thread so each thread can make its own guess and not update the mutable declared outside of it

I don't have your latest changes with the two different dicts it seems, but maybe this is enough to help 